### PR TITLE
feat: resolve the client IP behind trusted proxy hops

### DIFF
--- a/docs/guide-getting-started.md
+++ b/docs/guide-getting-started.md
@@ -74,8 +74,9 @@ func run() error {
 
 Order matters:
 
-- `oida.TracingMiddleware` goes **after** `middleware.RealIP` (so the remote address is the real one) and **after** `middleware.Recoverer` is registered if you want the recoverer to catch panics first — oida re-panics after recording, so either order records the failure; putting oida inside the recoverer keeps the 500 response behaviour of chi.
-- `frontend.Mount` must be called on a router that has the middleware registered, or on any router in the same process — the tracer is shared, not the router.
+- `middleware.RealIP` is optional for the recorded remote address: oida resolves the client IP from the `Forwarded` and `X-Forwarded-For` headers itself, skipping LAN and loopback hops (see [spec-model.md](spec-model.md)). Keep it when your own handlers read `r.RemoteAddr`.
+- `oida.TracingMiddleware` goes **after** `middleware.Recoverer` is registered if you want the recoverer to catch panics first. oida re-panics after recording, so either order records the failure; putting oida inside the recoverer keeps the 500 response behaviour of chi.
+- `frontend.Mount` must be called on a router that has the middleware registered, or on any router in the same process: the tracer is shared, not the router.
 - Routes registered *before* `r.Use` panic in chi; register middleware first.
 
 Visit `http://localhost:8080/debug/oida`.
@@ -98,7 +99,7 @@ Both routers talk to the same `opts.Tracer`, so the public router records and th
 
 `Options.RouteFunc` above is what makes statistics group `/users/1` and `/users/2` under `GET /users/{id}`: the middleware calls it *after* the handler ran, when chi's route context knows the matched pattern. Leave it out and every distinct URI becomes its own row.
 
-With `net/http` you do not need it — oida reads `http.Request.Pattern`.
+With `net/http` you do not need it: oida reads `http.Request.Pattern`.
 
 ## 3. net/http
 
@@ -149,6 +150,8 @@ opts.Authorize = func(r *http.Request) bool {
 	return ip != nil && (ip.IsLoopback() || ip.IsPrivate())
 }
 ```
+
+The check reads `r.RemoteAddr`, the connection peer, rather than the resolved client IP the traces record: a forwarded header is client input, so it cannot decide access.
 
 ## 5. Instrumenting the handler
 

--- a/docs/guide-getting-started.md
+++ b/docs/guide-getting-started.md
@@ -50,7 +50,6 @@ func run() error {
 	opts.Tracer = tracer
 
 	r := chi.NewRouter()
-	r.Use(middleware.RealIP)
 	r.Use(middleware.Recoverer)
 	r.Use(oida.TracingMiddleware(opts))
 
@@ -74,10 +73,11 @@ func run() error {
 
 Order matters:
 
-- `middleware.RealIP` is optional for the recorded remote address: oida resolves the client IP from the `Forwarded` and `X-Forwarded-For` headers itself, skipping LAN and loopback hops (see [spec-model.md](spec-model.md)). Keep it when your own handlers read `r.RemoteAddr`.
 - `oida.TracingMiddleware` goes **after** `middleware.Recoverer` is registered if you want the recoverer to catch panics first. oida re-panics after recording, so either order records the failure; putting oida inside the recoverer keeps the 500 response behaviour of chi.
 - `frontend.Mount` must be called on a router that has the middleware registered, or on any router in the same process: the tracer is shared, not the router.
 - Routes registered *before* `r.Use` panic in chi; register middleware first.
+
+`middleware.RealIP` is not in the example because oida does not need it: the middleware resolves the client IP from the `Forwarded` and `X-Forwarded-For` headers itself, skipping LAN and loopback hops (see [spec-model.md](spec-model.md)). The same resolution runs on a plain `net/http` mux (section 3), which has no RealIP equivalent. Add RealIP when your own chi handlers read `r.RemoteAddr` and expect the client address there.
 
 Visit `http://localhost:8080/debug/oida`.
 

--- a/docs/guide-getting-started.md
+++ b/docs/guide-getting-started.md
@@ -77,7 +77,7 @@ Order matters:
 - `frontend.Mount` must be called on a router that has the middleware registered, or on any router in the same process: the tracer is shared, not the router.
 - Routes registered *before* `r.Use` panic in chi; register middleware first.
 
-`middleware.RealIP` is not in the example because oida does not need it: the middleware resolves the client IP from the `Forwarded` and `X-Forwarded-For` headers itself, skipping LAN and loopback hops (see [spec-model.md](spec-model.md)). The same resolution runs on a plain `net/http` mux (section 3), which has no RealIP equivalent. Add RealIP when your own chi handlers read `r.RemoteAddr` and expect the client address there.
+> **Note**: chi provides `middleware.RealIP`, oida does not require it. The client IP is resolved from the `Forwarded` and `X-Forwarded-For` headers on any router (see [spec-model.md](spec-model.md)); add RealIP when your own handlers read `r.RemoteAddr`.
 
 Visit `http://localhost:8080/debug/oida`.
 

--- a/docs/spec-model.md
+++ b/docs/spec-model.md
@@ -101,6 +101,10 @@ type HTTPInfo struct {
 
 `Route` is the routed pattern supplied by `Options.RouteFunc` or `http.Request.Pattern`. Statistics prefer it over the raw URI.
 
+`RemoteAddress` is the resolved client IP, without a port. The middleware reads the `Forwarded` (RFC 7239) header, or `X-Forwarded-For` when `Forwarded` names no address, and walks the hops right to left, skipping 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16, 127.0.0.0/8, 169.254.0.0/16, ::1/128, fc00::/7 and fe80::/10: hops in those ranges are infrastructure, so the first address outside them is the client. Entries that hold no address, such as `unknown` or an obfuscated RFC 7239 identifier, are skipped.
+
+When every hop is inside those ranges, as with all-LAN traffic, the leftmost valid address wins. With no usable header the connection's own address is recorded, with the port stripped when it parses. There is nothing to configure; the ranges are fixed.
+
 ### Per-trace memory fields
 
 ```go

--- a/docs/spec-model.md
+++ b/docs/spec-model.md
@@ -101,7 +101,18 @@ type HTTPInfo struct {
 
 `Route` is the routed pattern supplied by `Options.RouteFunc` or `http.Request.Pattern`. Statistics prefer it over the raw URI.
 
-`RemoteAddress` is the resolved client IP, without a port. The middleware reads the `Forwarded` (RFC 7239) header, or `X-Forwarded-For` when `Forwarded` names no address, and walks the hops right to left, skipping 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16, 127.0.0.0/8, 169.254.0.0/16, ::1/128, fc00::/7 and fe80::/10: hops in those ranges are infrastructure, so the first address outside them is the client. Entries that hold no address, such as `unknown` or an obfuscated RFC 7239 identifier, are skipped.
+`RemoteAddress` is the resolved client IP, without a port. The middleware reads the `Forwarded` (RFC 7239) header, or `X-Forwarded-For` when `Forwarded` names no address, and walks the hops right to left. Hops in the trusted ranges are infrastructure, so the first address outside them is the client. The trusted ranges are:
+
+- 10.0.0.0/8
+- 172.16.0.0/12
+- 192.168.0.0/16
+- 127.0.0.0/8
+- 169.254.0.0/16
+- ::1/128
+- fc00::/7
+- fe80::/10
+
+Entries that hold no address, such as `unknown` or an obfuscated RFC 7239 identifier, are skipped.
 
 When every hop is inside those ranges, as with all-LAN traffic, the leftmost valid address wins. With no usable header the connection's own address is recorded, with the port stripped when it parses. There is nothing to configure; the ranges are fixed.
 

--- a/middleware.go
+++ b/middleware.go
@@ -54,7 +54,7 @@ func serveTraced(tracer *Tracer, opts Options, next http.Handler, w http.Respons
 		URI:           r.URL.RequestURI(),
 		Host:          r.Host,
 		Protocol:      r.Proto,
-		RemoteAddress: r.RemoteAddr,
+		RemoteAddress: remoteAddr(r),
 		UserAgent:     r.UserAgent(),
 	}
 	trace := tracer.begin(id, r.Method+" "+r.URL.Path, info)

--- a/remote_addr.go
+++ b/remote_addr.go
@@ -1,0 +1,108 @@
+package oida
+
+import (
+	"net/http"
+	"net/netip"
+	"strings"
+)
+
+// trustedNetworks lists the address ranges a forwarding hop can occupy without
+// being the client: RFC 1918 private space, loopback and link-local, plus their
+// IPv6 counterparts. Addresses in these ranges are infrastructure, not callers.
+var trustedNetworks = []netip.Prefix{
+	netip.MustParsePrefix("10.0.0.0/8"),
+	netip.MustParsePrefix("172.16.0.0/12"),
+	netip.MustParsePrefix("192.168.0.0/16"),
+	netip.MustParsePrefix("127.0.0.0/8"),
+	netip.MustParsePrefix("169.254.0.0/16"),
+	netip.MustParsePrefix("::1/128"),
+	netip.MustParsePrefix("fc00::/7"),
+	netip.MustParsePrefix("fe80::/10"),
+}
+
+// remoteAddr resolves the client IP of a request. It walks the forwarding
+// chain from the Forwarded (RFC 7239) or X-Forwarded-For headers right to left
+// and returns the first address outside the trusted LAN ranges: the hops a
+// proxy appended are trustworthy, anything to their left is client input. When
+// every hop is trusted, all-LAN traffic, the leftmost valid address is the
+// client. Without a usable header the request's own RemoteAddr decides.
+func remoteAddr(r *http.Request) string {
+	if r == nil {
+		return ""
+	}
+	chain := forwardedChain(r)
+	for i := len(chain) - 1; i >= 0; i-- {
+		if !trustedAddr(chain[i]) {
+			return chain[i].String()
+		}
+	}
+	if len(chain) > 0 {
+		return chain[0].String()
+	}
+	if addr, ok := parseForwardedAddr(r.RemoteAddr); ok {
+		return addr.String()
+	}
+	return r.RemoteAddr
+}
+
+// forwardedChain collects the forwarding chain from the request headers. The
+// standard Forwarded header wins when it names any address; X-Forwarded-For is
+// the fallback. Tokens that hold no address, RFC 7239 allows "unknown" and
+// obfuscated identifiers, are skipped.
+func forwardedChain(r *http.Request) []netip.Addr {
+	var chain []netip.Addr
+	for _, header := range r.Header.Values("Forwarded") {
+		for _, element := range strings.Split(header, ",") {
+			for _, pair := range strings.Split(element, ";") {
+				key, value, ok := strings.Cut(pair, "=")
+				if !ok || !strings.EqualFold(strings.TrimSpace(key), "for") {
+					continue
+				}
+				if addr, ok := parseForwardedAddr(value); ok {
+					chain = append(chain, addr)
+				}
+			}
+		}
+	}
+	if len(chain) > 0 {
+		return chain
+	}
+	for _, header := range r.Header.Values("X-Forwarded-For") {
+		for _, token := range strings.Split(header, ",") {
+			if addr, ok := parseForwardedAddr(token); ok {
+				chain = append(chain, addr)
+			}
+		}
+	}
+	return chain
+}
+
+// parseForwardedAddr parses one hop of a forwarding chain. It tolerates
+// surrounding whitespace and quotes, an attached port, IPv6 brackets and
+// zones, and reports anything else as not ok.
+func parseForwardedAddr(token string) (netip.Addr, bool) {
+	token = strings.TrimSpace(token)
+	token = strings.Trim(token, `"`)
+	if token == "" {
+		return netip.Addr{}, false
+	}
+	if addrPort, err := netip.ParseAddrPort(token); err == nil {
+		return addrPort.Addr().Unmap().WithZone(""), true
+	}
+	token = strings.TrimPrefix(token, "[")
+	token = strings.TrimSuffix(token, "]")
+	if addr, err := netip.ParseAddr(token); err == nil {
+		return addr.Unmap().WithZone(""), true
+	}
+	return netip.Addr{}, false
+}
+
+// trustedAddr reports whether addr sits in one of the trusted LAN ranges.
+func trustedAddr(addr netip.Addr) bool {
+	for _, network := range trustedNetworks {
+		if network.Contains(addr) {
+			return true
+		}
+	}
+	return false
+}

--- a/remote_addr_test.go
+++ b/remote_addr_test.go
@@ -1,0 +1,161 @@
+package oida
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestRemoteAddr(t *testing.T) {
+	tests := []struct {
+		name       string
+		remoteAddr string
+		headers    http.Header
+		want       string
+	}{
+		{
+			name:       "no headers strips the port",
+			remoteAddr: "203.0.113.7:52814",
+			want:       "203.0.113.7",
+		},
+		{
+			name:       "no headers and no port",
+			remoteAddr: "203.0.113.7",
+			want:       "203.0.113.7",
+		},
+		{
+			name:       "no headers keeps an unparseable remote addr",
+			remoteAddr: "@",
+			want:       "@",
+		},
+		{
+			name:       "single x-forwarded-for",
+			remoteAddr: "10.0.0.1:80",
+			headers:    http.Header{"X-Forwarded-For": {"198.51.100.4"}},
+			want:       "198.51.100.4",
+		},
+		{
+			name:       "x-forwarded-for with a port",
+			remoteAddr: "10.0.0.1:80",
+			headers:    http.Header{"X-Forwarded-For": {"198.51.100.4:8080"}},
+			want:       "198.51.100.4",
+		},
+		{
+			name:       "chained x-forwarded-for skips private hops",
+			remoteAddr: "127.0.0.1:80",
+			headers:    http.Header{"X-Forwarded-For": {"203.0.113.9, 10.0.0.1, 192.168.1.5"}},
+			want:       "203.0.113.9",
+		},
+		{
+			name:       "spoofed prefix loses to the rightmost public hop",
+			remoteAddr: "127.0.0.1:80",
+			headers:    http.Header{"X-Forwarded-For": {"1.2.3.4, 203.0.113.9, 172.16.4.4"}},
+			want:       "203.0.113.9",
+		},
+		{
+			name:       "x-forwarded-for split over two headers",
+			remoteAddr: "127.0.0.1:80",
+			headers:    http.Header{"X-Forwarded-For": {"203.0.113.9", "10.0.0.1"}},
+			want:       "203.0.113.9",
+		},
+		{
+			name:       "invalid tokens are skipped",
+			remoteAddr: "10.0.0.1:80",
+			headers:    http.Header{"X-Forwarded-For": {"garbage, 198.51.100.4, unknown, 10.0.0.1:port"}},
+			want:       "198.51.100.4",
+		},
+		{
+			name:       "only invalid tokens fall back to the remote addr",
+			remoteAddr: "203.0.113.7:443",
+			headers:    http.Header{"X-Forwarded-For": {"garbage, unknown"}},
+			want:       "203.0.113.7",
+		},
+		{
+			name:       "ipv6 with brackets",
+			remoteAddr: "[::1]:80",
+			headers:    http.Header{"X-Forwarded-For": {"[2001:db8::2]"}},
+			want:       "2001:db8::2",
+		},
+		{
+			name:       "ipv6 skips loopback and unique local hops",
+			remoteAddr: "[::1]:80",
+			headers:    http.Header{"X-Forwarded-For": {"2001:db8::2, fd00::5, ::1"}},
+			want:       "2001:db8::2",
+		},
+		{
+			name:       "ipv4 mapped ipv6 counts as its ipv4 range",
+			remoteAddr: "[::1]:80",
+			headers:    http.Header{"X-Forwarded-For": {"203.0.113.9, ::ffff:10.0.0.1"}},
+			want:       "203.0.113.9",
+		},
+		{
+			name:       "all private chain uses the leftmost hop",
+			remoteAddr: "127.0.0.1:80",
+			headers:    http.Header{"X-Forwarded-For": {"10.1.2.3, 192.168.0.9, 172.16.0.1"}},
+			want:       "10.1.2.3",
+		},
+		{
+			name:       "all private ipv6 chain uses the leftmost hop",
+			remoteAddr: "[::1]:80",
+			headers:    http.Header{"X-Forwarded-For": {"fd12::1, fe80::9"}},
+			want:       "fd12::1",
+		},
+		{
+			name:       "forwarded header",
+			remoteAddr: "10.0.0.1:80",
+			headers:    http.Header{"Forwarded": {"for=198.51.100.17;proto=https;by=203.0.113.43"}},
+			want:       "198.51.100.17",
+		},
+		{
+			name:       "forwarded header with quoted ipv6 and port",
+			remoteAddr: "10.0.0.1:80",
+			headers:    http.Header{"Forwarded": {`for=192.168.0.2, for="[2001:db8:cafe::17]:4711"`}},
+			want:       "2001:db8:cafe::17",
+		},
+		{
+			name:       "forwarded key is case insensitive",
+			remoteAddr: "10.0.0.1:80",
+			headers:    http.Header{"Forwarded": {`For="203.0.113.60:4711"`}},
+			want:       "203.0.113.60",
+		},
+		{
+			name:       "forwarded wins over x-forwarded-for",
+			remoteAddr: "10.0.0.1:80",
+			headers: http.Header{
+				"Forwarded":       {"for=198.51.100.17"},
+				"X-Forwarded-For": {"203.0.113.9"},
+			},
+			want: "198.51.100.17",
+		},
+		{
+			name:       "forwarded with only obfuscated hops falls back to x-forwarded-for",
+			remoteAddr: "10.0.0.1:80",
+			headers: http.Header{
+				"Forwarded":       {"for=unknown, for=_hidden"},
+				"X-Forwarded-For": {"203.0.113.9"},
+			},
+			want: "203.0.113.9",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := httptest.NewRequest(http.MethodGet, "/", nil)
+			r.RemoteAddr = tt.remoteAddr
+			for key, values := range tt.headers {
+				for _, value := range values {
+					r.Header.Add(key, value)
+				}
+			}
+			if got := remoteAddr(r); got != tt.want {
+				t.Fatalf("remoteAddr() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRemoteAddrNilRequest(t *testing.T) {
+	if got := remoteAddr(nil); got != "" {
+		t.Fatalf("remoteAddr(nil) = %q, want empty", got)
+	}
+}


### PR DESCRIPTION
Adds a config-free client IP resolver (issue option 2) and records it on every trace.

- New `remote_addr.go`: `remoteAddr(r)` walks the `Forwarded` (RFC 7239 `for=` pairs) and `X-Forwarded-For` chains right to left with `net/netip` and returns the first hop outside the trusted LAN ranges. An all-LAN chain falls back to the leftmost valid hop, and without a usable header the request's own `RemoteAddr` decides (port stripped when it parses). Quoted values, ports, IPv6 brackets and zones, 4-in-6 mapped addresses and garbage tokens are all handled.
- `middleware.go`: `serveTraced` records `RemoteAddress: remoteAddr(r)` instead of raw `r.RemoteAddr` (one line).
- `remote_addr_test.go`: table-driven tests for no headers, chained XFF with private hops, the Forwarded header, invalid entries, IPv6, and all-private chains.
- `docs/spec-model.md` documents the resolution order, the trusted ranges and the fallbacks under `RemoteAddress`; `docs/guide-getting-started.md` no longer credits `middleware.RealIP` for the recorded address and notes that `Options.Authorize` reads the connection's `r.RemoteAddr`, not the resolved client IP.

The trusted ranges:

- 10.0.0.0/8
- 172.16.0.0/12
- 192.168.0.0/16
- 127.0.0.0/8
- 169.254.0.0/16
- ::1/128
- fc00::/7
- fe80::/10

Closes #4.

Checklist:

- [x] Tests added or updated for the change
- [x] Documentation added or updated under docs/
- [x] The default atkins pipeline passes
- [x] Clean git tree: every generated file that is not .gitignored is committed (templ output)
- [x] go.mod/go.sum changes belong to the feature and are committed (no third-party PRs for go.mod changes will be considered) (none)
- [x] Frontend changes checked in both dark and light themes (none)

🤖 Generated with [Claude Code](https://claude.com/claude-code)